### PR TITLE
Fix dedicated server locking up on startup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ tasks.withType(JavaCompile) {
 }
 
 archivesBaseName = "Salts Mill"
-version = "0.4"
+version = "0.5"
 
 minecraft {
 	//refmapName = "mixins.ctr.refmap.json"

--- a/src/com/chocohead/sm/loader/CassetteLoader.java
+++ b/src/com/chocohead/sm/loader/CassetteLoader.java
@@ -12,10 +12,9 @@ import java.net.URLStreamHandler;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.Permission;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
-
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMap.Builder;
 
 import net.fabricmc.loader.api.FabricLoader;
 
@@ -92,7 +91,7 @@ class CassetteLoader {
 
 		for (Path wav : wavs) {
 			PreLoader.LOGGER.debug("Loading {}", wav);
-			Builder<String, byte[]> tracks = ImmutableMap.builder();
+			Map<String, byte[]> tracks = new HashMap<>();
 
 			try {
 				Cassette.readCompletely(wav, reader -> {
@@ -110,7 +109,7 @@ class CassetteLoader {
 			}
 
 			PreLoader.LOGGER.debug("Successfully loaded {}, adding to classpath", wav);
-			Map<String, byte[]> cassette = tracks.build();
+			Map<String, byte[]> cassette = Collections.unmodifiableMap(tracks);
 
 			boolean success = ClassTinkerers.addURL(CassetteSlot.engauge(wav.getFileName().toString(), cassette));
 			if (!success) throw new AssertionError("Failed to insert cassette!"); //A most terrible problem

--- a/src/com/chocohead/sm/loader/ResourceLoader.java
+++ b/src/com/chocohead/sm/loader/ResourceLoader.java
@@ -121,9 +121,10 @@ final class ResourceLoader extends Thread {
 
 	private static int countMatches(String s, char c) {
 		int result = 0;
-		while (s.indexOf(c) != -1) {
+		int index;
+		while ((index = s.indexOf(c)) != -1) {
 			result += 1;
-			s = s.substring(result + 1);
+			s = s.substring(index + 1);
 		}
 		return result;
 	}

--- a/src/com/chocohead/sm/loader/ResourceLoader.java
+++ b/src/com/chocohead/sm/loader/ResourceLoader.java
@@ -7,8 +7,6 @@ import java.util.Map.Entry;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.apache.commons.lang3.StringUtils;
-
 import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.InvalidIdentifierException;
@@ -94,7 +92,7 @@ final class ResourceLoader extends Thread {
 
 			for (Entry<String, byte[]> entry : allNameToContents.entrySet()) {
 				String file = entry.getKey();
-				if (StringUtils.countMatches(file, '/') < 2) continue; //Expecting at least [assets/data]/namespace/***
+				if (countMatches(file, '/') < 2) continue; //Expecting at least [assets/data]/namespace/***
 
 				int split = file.indexOf('/');
 				String type = file.substring(0, split++);
@@ -119,6 +117,15 @@ final class ResourceLoader extends Thread {
 		}
 
 		allNameToContents.clear();
+	}
+
+	private static int countMatches(String s, char c) {
+		int result = 0;
+		while (s.indexOf(c) != -1) {
+			result += 1;
+			s = s.substring(result + 1);
+		}
+		return result;
 	}
 
 	private static void load(Map<String, Map<String, Map<String, byte[]>>> typeToNamespace) {


### PR DESCRIPTION
I haven't quite figured out why yet, but for some reason loading StringUtils outside of the dev environment on a dedicated server causes the game to start prematurely. As a result, when StringUtils gets loaded from somewhere else, and class loading is implemented via locks, the first loading operation is not finished yet (because that's what caused the rest of the game to start loading in the first place) and it deadlocks at [KnotClassLoader.java:139](https://github.com/FabricMC/fabric-loader/blob/master/src/main/java/net/fabricmc/loader/launch/knot/KnotClassLoader.java#L139).

This reimplements countMatches so that it doesn't have to load StringUtils.

This fixes the issue, but RRP [currently seems to crash afterwards](https://hatebin.com/fqkmqinjuy) so I'll put this as a draft for now.